### PR TITLE
Fixed small error with KCC causing large velocity when overlapping

### DIFF
--- a/Assets/Scripts/Character/KinematicCharacterController.cs
+++ b/Assets/Scripts/Character/KinematicCharacterController.cs
@@ -458,7 +458,14 @@ namespace PropHunt.Character
             IMovingGround movingGround = floor == null ? null : floor.GetComponent<IMovingGround>();
             if (movingGround != null)
             {
-                groundVelocity = movingGround.GetVelocityAtPoint(groundHitPosition);
+                if (distanceToGround > 0)
+                {
+                    groundVelocity = movingGround.GetVelocityAtPoint(groundHitPosition);
+                }
+                else
+                {
+                    groundVelocity = movingGround.GetVelocityAtPoint(transform.position);
+                }
             }
 
             return groundVelocity;


### PR DESCRIPTION
Fixed small error with KCC causing large velocity when overlapping with an object.

# Description

Please include a summary of the change and which issue is fixed or what was added to the project. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
