### PR TITLE
Spectator Camera

### DIFF
--- a/Assets/Controls/InputSystem.inputactions
+++ b/Assets/Controls/InputSystem.inputactions
@@ -30,14 +30,6 @@
                     "interactions": ""
                 },
                 {
-                    "name": "Sprint",
-                    "type": "Button",
-                    "id": "3aa4111b-bb68-412d-bd3f-17bda7f2ca5d",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": ""
-                },
-                {
                     "name": "Fire",
                     "type": "Button",
                     "id": "e1d5dee9-5e26-4579-9d27-657776fa136c",
@@ -50,6 +42,22 @@
                     "type": "Value",
                     "id": "fb8d5e39-01f1-46e5-98de-be5b1d1f8f23",
                     "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "Forward",
+                    "type": "Button",
+                    "id": "04cf4c18-3190-4ab3-a318-eb918e165214",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "Backward",
+                    "type": "Button",
+                    "id": "01410572-e941-40b5-b45f-c5b2c59ca171",
+                    "expectedControlType": "Button",
                     "processors": "",
                     "interactions": ""
                 }
@@ -189,17 +197,6 @@
                 },
                 {
                     "name": "",
-                    "id": "6663e169-adaf-4d37-af8d-c5ce731ea772",
-                    "path": "<Keyboard>/leftShift",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Sprint",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "6ef13908-b9cf-4e5c-8a60-6da07d34c7b6",
                     "path": "<Mouse>/leftButton",
                     "interactions": "",
@@ -239,6 +236,28 @@
                     "processors": "",
                     "groups": "Joystick",
                     "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "54d360b7-ba76-42f3-b4da-d13fe361b6b6",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Backward",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "65177b74-5b51-4ede-b040-2ac7f6fba989",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Forward",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Controls/InputSystem.inputactions
+++ b/Assets/Controls/InputSystem.inputactions
@@ -51,7 +51,7 @@
                     "id": "04cf4c18-3190-4ab3-a318-eb918e165214",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "Press"
                 },
                 {
                     "name": "Backward",
@@ -59,7 +59,7 @@
                     "id": "01410572-e941-40b5-b45f-c5b2c59ca171",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "Press"
                 }
             ],
             "bindings": [
@@ -243,7 +243,7 @@
                     "name": "",
                     "id": "54d360b7-ba76-42f3-b4da-d13fe361b6b6",
                     "path": "<Keyboard>/leftCtrl",
-                    "interactions": "",
+                    "interactions": "Press",
                     "processors": "",
                     "groups": "",
                     "action": "Backward",
@@ -254,7 +254,7 @@
                     "name": "",
                     "id": "65177b74-5b51-4ede-b040-2ac7f6fba989",
                     "path": "<Keyboard>/leftShift",
-                    "interactions": "",
+                    "interactions": "Press",
                     "processors": "",
                     "groups": "",
                     "action": "Forward",
@@ -289,7 +289,7 @@
                     "id": "8d0c0094-dc57-4415-bf10-a3f3e0ff1f6b",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": ""
+                    "interactions": "Press"
                 },
                 {
                     "name": "Point",

--- a/Assets/Prefabs/Networking/NetworkManager.prefab
+++ b/Assets/Prefabs/Networking/NetworkManager.prefab
@@ -65,8 +65,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  inGamePlayer: {fileID: 1250752114043530695, guid: 2eeed3e45e5247b4a91826a6b0eb0f20, type: 3}
+  inGamePlayer: {fileID: 774360562829986131, guid: 94c1f054bcd31be429fd1ae1185e7267, type: 3}
   lobbyPlayer: {fileID: 1250752114043530695, guid: d3c7992bedb32c547a65b63a8702b3d8, type: 3}
+  spectatorPlayer: {fileID: 1250752114043530695, guid: 2eeed3e45e5247b4a91826a6b0eb0f20, type: 3}
 --- !u!114 &7367678013483490725
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Networking/NetworkManager.prefab
+++ b/Assets/Prefabs/Networking/NetworkManager.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  inGamePlayer: {fileID: 774360562829986131, guid: 94c1f054bcd31be429fd1ae1185e7267, type: 3}
+  inGamePlayer: {fileID: 1250752114043530695, guid: 2eeed3e45e5247b4a91826a6b0eb0f20, type: 3}
   lobbyPlayer: {fileID: 1250752114043530695, guid: d3c7992bedb32c547a65b63a8702b3d8, type: 3}
 --- !u!114 &7367678013483490725
 MonoBehaviour:
@@ -167,6 +167,7 @@ MonoBehaviour:
   - {fileID: 245587927565386927, guid: cd466bba068e4af4885e6e346a44616a, type: 3}
   - {fileID: 1250752114043530695, guid: d3c7992bedb32c547a65b63a8702b3d8, type: 3}
   - {fileID: 774360562829986131, guid: 94c1f054bcd31be429fd1ae1185e7267, type: 3}
+  - {fileID: 1250752114043530695, guid: 2eeed3e45e5247b4a91826a6b0eb0f20, type: 3}
   timerPrefab: {fileID: 5660222951667944539, guid: 0d379e827af7e944095b2c2ee6ffa675, type: 3}
 --- !u!114 &8542409671753137159
 MonoBehaviour:

--- a/Assets/Prefabs/Player/PlayerVariation.prefab
+++ b/Assets/Prefabs/Player/PlayerVariation.prefab
@@ -59,6 +59,7 @@ GameObject:
   - component: {fileID: 7132874320890653670}
   - component: {fileID: 2723596458813897958}
   - component: {fileID: -3663087370360975145}
+  - component: {fileID: 4705303200167846707}
   m_Layer: 0
   m_Name: PlayerVariation
   m_TagString: Player
@@ -543,23 +544,6 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 8963333518367223407}
-        m_TargetAssemblyTypeName: PropHunt.Character.KinematicCharacterController,
-          PropHunt
-        m_MethodName: OnSprint
-        m_Mode: 0
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls:
       - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: PropHunt.Combat.BasicRangedAttack, PropHunt
         m_MethodName: Attack
@@ -590,6 +574,14 @@ MonoBehaviour:
         m_CallState: 2
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Player
@@ -626,6 +618,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+--- !u!114 &4705303200167846707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 774360562829986131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da859f811529b0b428b2f67bec07515c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3969404203279134107
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player/PlayerVariation.prefab
+++ b/Assets/Prefabs/Player/PlayerVariation.prefab
@@ -59,7 +59,6 @@ GameObject:
   - component: {fileID: 7132874320890653670}
   - component: {fileID: 2723596458813897958}
   - component: {fileID: -3663087370360975145}
-  - component: {fileID: 4705303200167846707}
   m_Layer: 0
   m_Name: PlayerVariation
   m_TagString: Player
@@ -79,6 +78,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8719921445191087745}
+  - {fileID: 7735727211610086817}
   - {fileID: 6747082098351227875}
   - {fileID: 8922575349543282706}
   m_Father: {fileID: 0}
@@ -618,13 +618,44 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
---- !u!114 &4705303200167846707
+--- !u!1 &1159461200177953735
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7735727211610086817}
+  - component: {fileID: 5598218026211062919}
+  m_Layer: 0
+  m_Name: FollowPosition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7735727211610086817
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1159461200177953735}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3210544379120321374}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5598218026211062919
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 774360562829986131}
+  m_GameObject: {fileID: 1159461200177953735}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: da859f811529b0b428b2f67bec07515c, type: 3}
@@ -658,7 +689,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 3210544379120321374}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8113388304753193640
 GameObject:
@@ -691,7 +722,7 @@ Transform:
   m_LocalScale: {x: 0.95, y: 0.95, z: 0.95}
   m_Children: []
   m_Father: {fileID: 3210544379120321374}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!95 &3257078712940819048
 Animator:

--- a/Assets/Prefabs/Player/SpectatorPlayer.prefab
+++ b/Assets/Prefabs/Player/SpectatorPlayer.prefab
@@ -107,6 +107,8 @@ MonoBehaviour:
   syncMode: 0
   syncInterval: 0.1
   minSwapTime: 0.05
+  forwardAction: {fileID: -8014285966804362514, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  backwardAction: {fileID: -2296981732642237548, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   target: {fileID: 0}
 --- !u!114 &7336392193004563287
 MonoBehaviour:
@@ -206,35 +208,11 @@ MonoBehaviour:
     m_ActionId: d7430d8f-71d9-483c-8731-3fd065fcf16e
     m_ActionName: UI/TrackedDeviceOrientation
   - m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: -3571169171947004586}
-        m_TargetAssemblyTypeName: PropHunt.Spectator.SpectatorFollow, FallingParkour
-        m_MethodName: NextTarget
-        m_Mode: 3
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 1
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
     m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
     m_ActionName: Player/Forward[/Keyboard/leftShift]
   - m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: -3571169171947004586}
-        m_TargetAssemblyTypeName: PropHunt.Spectator.SpectatorFollow, FallingParkour
-        m_MethodName: NextTarget
-        m_Mode: 3
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: -1
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
     m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
     m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0

--- a/Assets/Prefabs/Player/SpectatorPlayer.prefab
+++ b/Assets/Prefabs/Player/SpectatorPlayer.prefab
@@ -106,6 +106,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
+  minSwapTime: 0.05
   target: {fileID: 0}
 --- !u!114 &7336392193004563287
 MonoBehaviour:
@@ -313,7 +314,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8034969259794235780}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 2, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1250752114043530690}

--- a/Assets/Prefabs/Player/SpectatorPlayer.prefab
+++ b/Assets/Prefabs/Player/SpectatorPlayer.prefab
@@ -1,0 +1,321 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1250752114043530695
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1250752114043530690}
+  - component: {fileID: 1250752114043530689}
+  - component: {fileID: 1250752114043530688}
+  - component: {fileID: 1250752114043530691}
+  - component: {fileID: -3571169171947004586}
+  - component: {fileID: 7336392193004563287}
+  - component: {fileID: 6682297993583463045}
+  - component: {fileID: 722526358148954805}
+  m_Layer: 0
+  m_Name: SpectatorPlayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1250752114043530690
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250752114043530695}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4211834296241639000}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1250752114043530689
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250752114043530695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 0
+  serverOnly: 0
+  visible: 0
+  m_AssetId: 
+  hasSpawned: 0
+--- !u!114 &1250752114043530688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250752114043530695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 1
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
+  compressRotation: 0
+  interpolateScale: 1
+  syncScale: 1
+--- !u!114 &1250752114043530691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250752114043530695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb864185cc1837e40a8b45affc6a65f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  playerId: 0
+  characterName: Player
+--- !u!114 &-3571169171947004586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250752114043530695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99936fe44edda614da7345ec5e1fe84e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  target: {fileID: 0}
+--- !u!114 &7336392193004563287
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250752114043530695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+  m_NotificationBehavior: 2
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 8ea09493-fee6-42c4-ac08-4022f4cc5408
+    m_ActionName: Player/Move[/Keyboard/w,/Keyboard/s,/Keyboard/a,/Keyboard/d,/Keyboard/upArrow,/Keyboard/downArrow,/Keyboard/leftArrow,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: bca05cba-8116-4a1d-9624-dc2929c1d827
+    m_ActionName: Player/Jump[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 0ed934b6-561e-48cb-a120-77501fb43610
+    m_ActionName: Player/Interact[/Keyboard/e]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
+    m_ActionName: Player/Fire[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6682297993583463045}
+        m_TargetAssemblyTypeName: PropHunt.Character.CameraController, FallingParkour
+        m_MethodName: OnLook
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
+    m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: e9ea2153-a41c-4da0-9c54-c767c562bb40
+    m_ActionName: UI/Navigate[/Keyboard/w,/Keyboard/upArrow,/Keyboard/s,/Keyboard/downArrow,/Keyboard/a,/Keyboard/leftArrow,/Keyboard/d,/Keyboard/rightArrow]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 558b280e-5543-4776-b4e4-43e4b1fb8b60
+    m_ActionName: UI/Submit[/Keyboard/enter]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 8d0c0094-dc57-4415-bf10-a3f3e0ff1f6b
+    m_ActionName: UI/Cancel[/Keyboard/escape]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 816778a0-1877-4b52-a8dc-ea745d71233e
+    m_ActionName: UI/Point[/Mouse/position]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: e72873b5-76f9-4821-a13f-221cee17d091
+    m_ActionName: UI/Click[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 9e8e5a65-b053-4aa6-926d-f089d369fe8b
+    m_ActionName: UI/ScrollWheel[/Mouse/scroll]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 1520ee3a-e59c-4097-8c3f-2fa121a7b26d
+    m_ActionName: UI/MiddleClick[/Mouse/middleButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 426533ef-12d3-4aff-a0c0-12e26cb118c9
+    m_ActionName: UI/RightClick[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 8ea2ed25-c28d-4812-9f01-a5b2bde212d7
+    m_ActionName: UI/TrackedDevicePosition
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: d7430d8f-71d9-483c-8731-3fd065fcf16e
+    m_ActionName: UI/TrackedDeviceOrientation
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: -3571169171947004586}
+        m_TargetAssemblyTypeName: PropHunt.Spectator.SpectatorFollow, FallingParkour
+        m_MethodName: NextTarget
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: -3571169171947004586}
+        m_TargetAssemblyTypeName: PropHunt.Spectator.SpectatorFollow, FallingParkour
+        m_MethodName: NextTarget
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: -1
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: Player
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
+--- !u!114 &6682297993583463045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250752114043530695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 88dccdbb9c3c8ed48ac11483313f02d8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  maxPitch: 90
+  minPitch: -90
+  rotationRate: 180
+  frameRotation: 0
+  cameraTransform: {fileID: 4211834296241639000}
+  pitchBody: 0
+  baseCameraOffset: {x: 0, y: 0, z: 0}
+  minCameraDistance: 2
+  maxCameraDistance: 2
+  currentDistance: 0
+  zoomSpeed: 1
+  cameraRaycastMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  shadowOnlyDistance: 0.5
+  ditherDistance: 1
+  thirdPersonCharacterBase: {fileID: 0}
+  transitionTime: 0.1
+--- !u!114 &722526358148954805
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1250752114043530695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c2dfef40ed05324f842ce2eb43e4d48, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  cameraController: {fileID: 6682297993583463045}
+  audioListener: {fileID: 0}
+--- !u!1 &8034969259794235780
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4211834296241639000}
+  m_Layer: 0
+  m_Name: Camera Offset
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4211834296241639000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8034969259794235780}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1250752114043530690}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Player/SpectatorPlayer.prefab.meta
+++ b/Assets/Prefabs/Player/SpectatorPlayer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2eeed3e45e5247b4a91826a6b0eb0f20
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UI/Components/ControlsPanel.prefab
+++ b/Assets/Prefabs/UI/Components/ControlsPanel.prefab
@@ -429,9 +429,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 3191918249103320638}
-  - {fileID: 5403715746910586586}
-  - {fileID: 3230185720635334021}
-  - {fileID: 1013250093502171877}
+  - {fileID: 2723127012462120818}
+  - {fileID: 3848859433965933920}
   - {fileID: 8365573580727697150}
   m_Father: {fileID: 7782518715594943783}
   m_RootOrder: 1
@@ -2252,11 +2251,11 @@ RectTransform:
   - {fileID: 5411387490482538294}
   - {fileID: 4213538897301601840}
   m_Father: {fileID: 1168780547179336923}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -35}
+  m_AnchoredPosition: {x: 0, y: -105}
   m_SizeDelta: {x: 0, y: 145}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1982146887189126198
@@ -2693,242 +2692,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!1001 &2595876530333180859
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1168780547179336923}
-    m_Modifications:
-    - target: {fileID: 1143783389990515084, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_Text
-      value: Interact
-      objectReference: {fileID: 0}
-    - target: {fileID: 6478665345003004389, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: inputAction
-      value: 
-      objectReference: {fileID: 715019269035726934, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-    - target: {fileID: 6478665345003004389, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: menuController
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -35
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9024761054527596345, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_Name
-      value: Interact Action Rebind
-      objectReference: {fileID: 0}
-    - target: {fileID: 9024761054527596345, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
---- !u!224 &5403715746910586586 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-  m_PrefabInstance: {fileID: 2595876530333180859}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &4767150264249497828
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1168780547179336923}
-    m_Modifications:
-    - target: {fileID: 1143783389990515084, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_Text
-      value: Attack
-      objectReference: {fileID: 0}
-    - target: {fileID: 6478665345003004389, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: inputAction
-      value: 
-      objectReference: {fileID: -1967586286439442731, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-    - target: {fileID: 6478665345003004389, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: menuController
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 30
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -70
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9024761054527596345, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_Name
-      value: Fire Action Rebind
-      objectReference: {fileID: 0}
-    - target: {fileID: 9024761054527596345, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
---- !u!224 &3230185720635334021 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-  m_PrefabInstance: {fileID: 4767150264249497828}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4805417323477451615
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3043,7 +2806,7 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
   m_PrefabInstance: {fileID: 4805417323477451615}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &6986337235940814724
+--- !u!1001 &5418323701979507219
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -3052,12 +2815,12 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1143783389990515084, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
       propertyPath: m_Text
-      value: Sprint
+      value: Jump
       objectReference: {fileID: 0}
     - target: {fileID: 6478665345003004389, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
       propertyPath: inputAction
       value: 
-      objectReference: {fileID: -8679611187127702482, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+      objectReference: {fileID: -8014285966804362514, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
     - target: {fileID: 6478665345003004389, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
       propertyPath: menuController
       value: 
@@ -3072,7 +2835,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3132,7 +2895,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -105
+      value: -35
       objectReference: {fileID: 0}
     - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -3148,16 +2911,126 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9024761054527596345, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
       propertyPath: m_Name
-      value: Sprint Action Rebind
-      objectReference: {fileID: 0}
-    - target: {fileID: 9024761054527596345, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-      propertyPath: m_IsActive
-      value: 0
+      value: Forward Action Rebind
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
---- !u!224 &1013250093502171877 stripped
+--- !u!224 &2723127012462120818 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
-  m_PrefabInstance: {fileID: 6986337235940814724}
+  m_PrefabInstance: {fileID: 5418323701979507219}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6598433604688244737
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1168780547179336923}
+    m_Modifications:
+    - target: {fileID: 1143783389990515084, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_Text
+      value: Jump
+      objectReference: {fileID: 0}
+    - target: {fileID: 6478665345003004389, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: inputAction
+      value: 
+      objectReference: {fileID: -2296981732642237548, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
+    - target: {fileID: 6478665345003004389, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: menuController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -70
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024761054527596345, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+      propertyPath: m_Name
+      value: Backward Action Rebind
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+--- !u!224 &3848859433965933920 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7997193526154765665, guid: 61ac36d9a73bfd14da738b5c7ab407d5, type: 3}
+  m_PrefabInstance: {fileID: 6598433604688244737}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/UI/Screens/ConnectingMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/ConnectingMenu.prefab
@@ -282,16 +282,20 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls: []
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: UI

--- a/Assets/Prefabs/UI/Screens/CreditsScreen.prefab
+++ b/Assets/Prefabs/UI/Screens/CreditsScreen.prefab
@@ -789,16 +789,20 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls: []
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: UI

--- a/Assets/Prefabs/UI/Screens/InGameHUD.prefab
+++ b/Assets/Prefabs/UI/Screens/InGameHUD.prefab
@@ -212,16 +212,20 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls: []
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: UI

--- a/Assets/Prefabs/UI/Screens/InGameMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/InGameMenu.prefab
@@ -860,16 +860,20 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls: []
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: UI

--- a/Assets/Prefabs/UI/Screens/LobbyScreen.prefab
+++ b/Assets/Prefabs/UI/Screens/LobbyScreen.prefab
@@ -965,16 +965,20 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls: []
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: UI

--- a/Assets/Prefabs/UI/Screens/MainMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/MainMenu.prefab
@@ -2631,16 +2631,20 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls: []
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: UI

--- a/Assets/Prefabs/UI/Screens/ServerMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/ServerMenu.prefab
@@ -228,16 +228,20 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls: []
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: UI

--- a/Assets/Prefabs/UI/Screens/SettingsMenu.prefab
+++ b/Assets/Prefabs/UI/Screens/SettingsMenu.prefab
@@ -1569,16 +1569,20 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
       m_Calls: []
     m_ActionId: fb8d5e39-01f1-46e5-98de-be5b1d1f8f23
     m_ActionName: Player/Look[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: UI
@@ -2102,10 +2106,18 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 379990221835961574}
     m_Modifications:
+    - target: {fileID: 178613091296661988, guid: 41ed1f3ea1c87a642aff34e3ef31d741, type: 3}
+      propertyPath: menuController
+      value: 
+      objectReference: {fileID: 8387962290575963714}
     - target: {fileID: 1190656660190202813, guid: 41ed1f3ea1c87a642aff34e3ef31d741, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1358142589426519030, guid: 41ed1f3ea1c87a642aff34e3ef31d741, type: 3}
+      propertyPath: menuController
+      value: 
+      objectReference: {fileID: 8387962290575963714}
     - target: {fileID: 1970485735994188474, guid: 41ed1f3ea1c87a642aff34e3ef31d741, type: 3}
       propertyPath: menuController
       value: 
@@ -2122,6 +2134,14 @@ PrefabInstance:
       propertyPath: menuController
       value: 
       objectReference: {fileID: 8387962290575963714}
+    - target: {fileID: 4966987007247063967, guid: 41ed1f3ea1c87a642aff34e3ef31d741, type: 3}
+      propertyPath: m_Text
+      value: Spectate Next
+      objectReference: {fileID: 0}
+    - target: {fileID: 6074740762125336973, guid: 41ed1f3ea1c87a642aff34e3ef31d741, type: 3}
+      propertyPath: m_Text
+      value: Spectate Previous
+      objectReference: {fileID: 0}
     - target: {fileID: 7062921866573081865, guid: 41ed1f3ea1c87a642aff34e3ef31d741, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -2273,6 +2293,10 @@ PrefabInstance:
       propertyPath: settingsMenuController
       value: 
       objectReference: {fileID: 8387962290575963714}
+    - target: {fileID: 6187564329407797762, guid: d506a7fdd3f951b48884766faf07bbbb, type: 3}
+      propertyPath: m_Value
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7694884257995294999, guid: d506a7fdd3f951b48884766faf07bbbb, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -2394,6 +2418,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2341118136139976102, guid: d32b2dbaab0edd84482f589d5d271415, type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2470670762500057116, guid: d32b2dbaab0edd84482f589d5d271415, type: 3}
+      propertyPath: m_Value
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3196738492181952199, guid: d32b2dbaab0edd84482f589d5d271415, type: 3}

--- a/Assets/Prefabs/UI/UIManager.prefab
+++ b/Assets/Prefabs/UI/UIManager.prefab
@@ -243,10 +243,6 @@ MonoBehaviour:
     m_ActionName: Player/Interact[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls: []
-    m_ActionId: 3aa4111b-bb68-412d-bd3f-17bda7f2ca5d
-    m_ActionName: Player/Sprint[/Keyboard/leftShift]
-  - m_PersistentCalls:
-      m_Calls: []
     m_ActionId: e1d5dee9-5e26-4579-9d27-657776fa136c
     m_ActionName: Player/Fire[/Mouse/leftButton]
   - m_PersistentCalls:
@@ -293,6 +289,14 @@ MonoBehaviour:
       m_Calls: []
     m_ActionId: d7430d8f-71d9-483c-8731-3fd065fcf16e
     m_ActionName: UI/TrackedDeviceOrientation
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 04cf4c18-3190-4ab3-a318-eb918e165214
+    m_ActionName: Player/Forward[/Keyboard/leftShift]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 01410572-e941-40b5-b45f-c5b2c59ca171
+    m_ActionName: Player/Backward[/Keyboard/leftCtrl]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Player

--- a/Assets/Scenes/BigFans.unity
+++ b/Assets/Scenes/BigFans.unity
@@ -1361,53 +1361,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 249697813445521289, guid: afa0896c30a36284b96f815ca6f4feb7, type: 3}
   m_PrefabInstance: {fileID: 631978577}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &673954851
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 673954853}
-  - component: {fileID: 673954852}
-  m_Layer: 0
-  m_Name: Checkpoint Matrix
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &673954852
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 673954851}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4802a01e94b1afd498a51a6bf302c089, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  order: 5
-  offset: {x: 1, y: 1}
-  rows: 4
-  cols: 9
---- !u!4 &673954853
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 673954851}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -4, y: 1, z: 14}
-  m_LocalScale: {x: 10, y: 1, z: 4}
-  m_Children: []
-  m_Father: {fileID: 1474827462}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &677914804
 GameObject:
   m_ObjectHideFlags: 0
@@ -2281,6 +2234,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1069172165}
   - component: {fileID: 1069172167}
+  - component: {fileID: 1069172168}
   - component: {fileID: 1069172166}
   m_Layer: 0
   m_Name: Checkpoint Flag
@@ -2297,11 +2251,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1069172164}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 13}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1474827462}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1069172166
 MonoBehaviour:
@@ -2312,10 +2266,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 1069172164}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7cc81e316d74c474da68f982e35ece11, type: 3}
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  checkpoint: {fileID: 673954851}
+  sceneId: 1660369395
+  serverOnly: 0
+  visible: 0
+  m_AssetId: 
+  hasSpawned: 0
 --- !u!65 &1069172167
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -2327,8 +2285,23 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 10, y: 20, z: 4}
+  m_Size: {x: 10, y: 20, z: 10}
   m_Center: {x: 0, y: 10, z: 0}
+--- !u!114 &1069172168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1069172164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fa5bd002477ea20439cf62440f4d53bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  playerSpawnManager: {fileID: 0}
 --- !u!1 &1138675822
 GameObject:
   m_ObjectHideFlags: 0
@@ -3328,7 +3301,6 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1511698997}
-  - {fileID: 673954853}
   - {fileID: 1069172165}
   m_Father: {fileID: 0}
   m_RootOrder: 16

--- a/Assets/Scenes/BigFans.unity
+++ b/Assets/Scenes/BigFans.unity
@@ -423,7 +423,7 @@ GameObject:
   m_Component:
   - component: {fileID: 72499353}
   m_Layer: 0
-  m_Name: GameObject
+  m_Name: Spec Target Parent
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1515,6 +1515,7 @@ GameObject:
   - component: {fileID: 820096636}
   - component: {fileID: 820096638}
   - component: {fileID: 820096637}
+  - component: {fileID: 820096639}
   m_Layer: 0
   m_Name: Moving Target
   m_TagString: Untagged
@@ -1573,6 +1574,27 @@ MonoBehaviour:
   visible: 0
   m_AssetId: 
   hasSpawned: 0
+--- !u!114 &820096639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 820096635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f74aedd71d9a4f55b3ce499326d45fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  clientAuthority: 0
+  localPositionSensitivity: 0.01
+  localRotationSensitivity: 0.01
+  localScaleSensitivity: 0.01
+  compressRotation: 0
+  interpolateScale: 1
+  syncScale: 1
 --- !u!1 &878899127
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/BigFans.unity
+++ b/Assets/Scenes/BigFans.unity
@@ -303,6 +303,36 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8431909921260752297, guid: 12f6f24423a226e4ca88101b3b6dc862, type: 3}
   m_PrefabInstance: {fileID: 18196584}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &34693117
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 34693118}
+  m_Layer: 0
+  m_Name: Point 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &34693118
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 34693117}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 72499353}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &46361210
 GameObject:
   m_ObjectHideFlags: 0
@@ -382,6 +412,39 @@ Transform:
   - {fileID: 464740574}
   m_Father: {fileID: 0}
   m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &72499352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 72499353}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &72499353
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 72499352}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 820096636}
+  - {fileID: 1964600772}
+  - {fileID: 34693118}
+  m_Father: {fileID: 0}
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &145261819
 GameObject:
@@ -1488,6 +1551,75 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 784284474}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &820096635
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 820096636}
+  - component: {fileID: 820096638}
+  - component: {fileID: 820096637}
+  m_Layer: 0
+  m_Name: Moving Target
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &820096636
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 820096635}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1421633136}
+  m_Father: {fileID: 72499353}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &820096637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 820096635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9e71d8b5fbfda545b729900444b08df, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  syncMode: 0
+  syncInterval: 0.1
+  linearSpeed: 3
+  targetsList:
+  - {fileID: 1964600772}
+  - {fileID: 34693118}
+  moved: {x: 0, y: 0, z: 0}
+--- !u!114 &820096638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 820096635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b91ecbcc199f4492b9a91e820070131, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sceneId: 984985913
+  serverOnly: 0
+  visible: 0
+  m_AssetId: 
+  hasSpawned: 0
 --- !u!1 &878899127
 GameObject:
   m_ObjectHideFlags: 0
@@ -1870,6 +2002,49 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7560938382942759585, guid: df3f3f96dc09b9341bebb4215f018931, type: 3}
   m_PrefabInstance: {fileID: 953949880}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &955521268
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 955521269}
+  - component: {fileID: 955521270}
+  m_Layer: 0
+  m_Name: Spec Target 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &955521269
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955521268}
+  m_LocalRotation: {x: -0, y: 0.42851478, z: -0, w: 0.90353477}
+  m_LocalPosition: {x: -12.75, y: -2.5090086, z: 6.93}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 50.747, z: 0}
+--- !u!114 &955521270
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955521268}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da859f811529b0b428b2f67bec07515c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &980147683
 GameObject:
   m_ObjectHideFlags: 0
@@ -2810,6 +2985,49 @@ Transform:
   m_Father: {fileID: 1802342685}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 35, y: 180, z: 0}
+--- !u!1 &1421633133
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1421633136}
+  - component: {fileID: 1421633134}
+  m_Layer: 0
+  m_Name: Spec Target 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1421633134
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1421633133}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da859f811529b0b428b2f67bec07515c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1421633136
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1421633133}
+  m_LocalRotation: {x: -0.051890127, y: -0.31818202, z: -0.15236317, w: 0.9342661}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 820096636}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -11.181, y: -36.151, z: -14.865}
 --- !u!1 &1438153605
 GameObject:
   m_ObjectHideFlags: 0
@@ -4182,6 +4400,36 @@ Transform:
   m_LocalScale: {x: 10, y: 1, z: 4}
   m_Children: []
   m_Father: {fileID: 1796088229}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1964600771
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1964600772}
+  m_Layer: 0
+  m_Name: Point 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1964600772
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1964600771}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 50}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 72499353}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2036535251

--- a/Assets/Scripts/Game/Flow/ChangeToSpectator.cs
+++ b/Assets/Scripts/Game/Flow/ChangeToSpectator.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Mirror;
+using PropHunt.Character;
+using UnityEngine;
+
+namespace PropHunt.Game.Flow
+{
+    /// <summary>
+    /// A Box that, when entered by a player, will change player to a spectator.
+    /// </summary>
+    public class ChangeToSpectator : NetworkBehaviour
+    {
+        public PlayerSpawnManager playerSpawnManager;
+
+        public void Start()
+        {
+            playerSpawnManager = GameObject.FindObjectOfType<PlayerSpawnManager>();
+        }
+
+        public void OnTriggerEnter(Collider other)
+        {
+            GameObject otherObj = other.gameObject;
+            CharacterName character = otherObj.GetComponent<CharacterName>();
+            if (isServer && character != null)
+            {
+                StartCoroutine(playerSpawnManager.SpawnPlayerCharacter(character.connectionToClient, playerSpawnManager.spectatorPlayer));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Game/Flow/ChangeToSpectator.cs.meta
+++ b/Assets/Scripts/Game/Flow/ChangeToSpectator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa5bd002477ea20439cf62440f4d53bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Flow/PlayerSpawnManager.cs
+++ b/Assets/Scripts/Game/Flow/PlayerSpawnManager.cs
@@ -5,17 +5,32 @@ using PropHunt.Environment.Checkpoint;
 
 namespace PropHunt.Game.Flow
 {
+    /// <summary>
+    /// Spawn manager for creating and managing player in the game. 
+    /// </summary>
     public class PlayerSpawnManager : NetworkBehaviour
     {
+        /// <summary>
+        /// In game player for running through levels.
+        /// </summary>
         public GameObject inGamePlayer;
 
+        /// <summary>
+        /// Lobby player for sitting in the lobby scene.
+        /// </summary>
         public GameObject lobbyPlayer;
+
+        /// <summary>
+        /// Spectator player for watching other players in the game.
+        /// </summary>
+        public GameObject spectatorPlayer;
 
         public override void OnStartClient()
         {
             base.OnStartClient();
             NetworkClient.RegisterPrefab(inGamePlayer);
             NetworkClient.RegisterPrefab(lobbyPlayer);
+            NetworkClient.RegisterPrefab(spectatorPlayer);
         }
 
         public override void OnStartServer()
@@ -54,10 +69,15 @@ namespace PropHunt.Game.Flow
                 {
                     (pos, rot) = defaultCheckpoint.GetRandomSpawn();
                 }
-                StartCoroutine(SpawnPlayerCharacter(joinEvent.connection, inGamePlayer, pos, rot));
+                StartCoroutine(SpawnPlayerCharacter(joinEvent.connection, spectatorPlayer, pos, rot));
             }
             else if (GameManager.gamePhase == GamePhase.Lobby)
             {
+                StartCoroutine(SpawnPlayerCharacter(joinEvent.connection, lobbyPlayer));
+            }
+            else
+            {
+                // Default spawn a lobby player for the player character
                 StartCoroutine(SpawnPlayerCharacter(joinEvent.connection, lobbyPlayer));
             }
         }

--- a/Assets/Scripts/Spectator.meta
+++ b/Assets/Scripts/Spectator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0203891422cd2a49ba58d52e242f9bc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spectator/Followable.cs
+++ b/Assets/Scripts/Spectator/Followable.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Mirror;
+using UnityEngine;
+
+namespace PropHunt.Spectator
+{
+    /// <summary>
+    /// An object that can be followed by a spectator player
+    /// </summary>
+    public class Followable : MonoBehaviour, IComparable<Followable>
+    {
+        /// <summary>
+        /// Start each followable object with a random GUID id
+        /// </summary>
+        private Guid id = Guid.NewGuid();
+
+        /// <summary>
+        /// Get identifier for this followable object
+        /// </summary>
+        public Guid Id => id;
+
+        public int CompareTo(Followable other)
+        {
+            return id.CompareTo(other.id);
+        }
+    }
+}

--- a/Assets/Scripts/Spectator/Followable.cs.meta
+++ b/Assets/Scripts/Spectator/Followable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da859f811529b0b428b2f67bec07515c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spectator/SpectatorFollow.cs
+++ b/Assets/Scripts/Spectator/SpectatorFollow.cs
@@ -12,6 +12,18 @@ namespace PropHunt.Spectator
     public class SpectatorFollow : NetworkBehaviour
     {
         /// <summary>
+        /// Minimum time between player target swaps.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Minimum time between player follow target swaps")]
+        private float minSwapTime = 0.05f;
+
+        /// <summary>
+        /// Last time in which the player swapped targets.
+        /// </summary>
+        private float lastSwapTime = Mathf.NegativeInfinity;
+
+        /// <summary>
         /// What is the player currently following?
         /// </summary>
         [SerializeField]
@@ -35,7 +47,7 @@ namespace PropHunt.Spectator
         {
             NextTarget(0);
         }
-        
+
         /// <summary>
         /// Get the list of all followable objects currently in the scene.
         /// Will return followable objects in a consistent order
@@ -54,8 +66,9 @@ namespace PropHunt.Spectator
         /// <param name="step">Direction and count to move forward in followable list.</param>
         public void NextTarget(int step = 1)
         {
-            if (isLocalPlayer)
+            if (isLocalPlayer && Time.time - lastSwapTime >= minSwapTime)
             {
+                lastSwapTime = Time.time;
                 List<Followable> followables = GetFollowables();
                 UnityEngine.Debug.Log("followables = " + followables + " total = " + followables.Count.ToString());
                 if (followables.Count > 0)

--- a/Assets/Scripts/Spectator/SpectatorFollow.cs
+++ b/Assets/Scripts/Spectator/SpectatorFollow.cs
@@ -1,0 +1,69 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Mirror;
+using UnityEngine;
+
+namespace PropHunt.Spectator
+{
+    /// <summary>
+    /// Script to track a spectatable object
+    /// </summary>
+    public class SpectatorFollow : NetworkBehaviour
+    {
+        /// <summary>
+        /// What is the player currently following?
+        /// </summary>
+        [SerializeField]
+        private Followable target;
+
+        /// <summary>
+        /// Update function to have the player follow the current target object.
+        /// </summary>
+        public void LateUpdate()
+        {
+            if (target != null)
+            {
+                transform.position = target.transform.position;
+            }
+        }
+
+        /// <summary>
+        /// Initialize player position and target
+        /// </summary>
+        public void Start()
+        {
+            NextTarget(0);
+        }
+        
+        /// <summary>
+        /// Get the list of all followable objects currently in the scene.
+        /// Will return followable objects in a consistent order
+        /// </summary>
+        /// <returns>List of all followable objects.</returns>
+        public static List<Followable> GetFollowables()
+        {
+            var followables = new List<Followable>(GameObject.FindObjectsOfType<Followable>());
+            followables.Sort((Followable a, Followable b) => a.CompareTo(b));
+            return followables;
+        }
+
+        /// <summary>
+        /// Change target to next target out of all targets currently in the scene.
+        /// </summary>
+        /// <param name="step">Direction and count to move forward in followable list.</param>
+        public void NextTarget(int step = 1)
+        {
+            if (isLocalPlayer)
+            {
+                List<Followable> followables = GetFollowables();
+                UnityEngine.Debug.Log("followables = " + followables + " total = " + followables.Count.ToString());
+                if (followables.Count > 0)
+                {
+                    int index = followables.FindIndex(0, other => other == target);
+                    target = followables[((index + step) + followables.Count) % followables.Count];
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Spectator/SpectatorFollow.cs
+++ b/Assets/Scripts/Spectator/SpectatorFollow.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Mirror;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace PropHunt.Spectator
 {
@@ -12,16 +13,18 @@ namespace PropHunt.Spectator
     public class SpectatorFollow : NetworkBehaviour
     {
         /// <summary>
-        /// Minimum time between player target swaps.
+        /// Action to move to next spectator object.
         /// </summary>
         [SerializeField]
         [Tooltip("Minimum time between player follow target swaps")]
-        private float minSwapTime = 0.05f;
+        private UnityEngine.InputSystem.InputActionReference forwardAction;
 
         /// <summary>
-        /// Last time in which the player swapped targets.
+        /// Action to move to previous spectator object.
         /// </summary>
-        private float lastSwapTime = Mathf.NegativeInfinity;
+        [SerializeField]
+        [Tooltip("Minimum time between player follow target swaps")]
+        private UnityEngine.InputSystem.InputActionReference backwardAction;
 
         /// <summary>
         /// What is the player currently following?
@@ -46,6 +49,8 @@ namespace PropHunt.Spectator
         public void Start()
         {
             NextTarget(0);
+            forwardAction.action.started += action => NextTarget(1);
+            backwardAction.action.started += action => NextTarget(-1);
         }
 
         /// <summary>
@@ -66,11 +71,9 @@ namespace PropHunt.Spectator
         /// <param name="step">Direction and count to move forward in followable list.</param>
         public void NextTarget(int step = 1)
         {
-            if (isLocalPlayer && Time.time - lastSwapTime >= minSwapTime)
+            if (isLocalPlayer)
             {
-                lastSwapTime = Time.time;
                 List<Followable> followables = GetFollowables();
-                UnityEngine.Debug.Log("followables = " + followables + " total = " + followables.Count.ToString());
                 if (followables.Count > 0)
                 {
                     int index = followables.FindIndex(0, other => other == target);

--- a/Assets/Scripts/Spectator/SpectatorFollow.cs
+++ b/Assets/Scripts/Spectator/SpectatorFollow.cs
@@ -17,14 +17,14 @@ namespace PropHunt.Spectator
         /// </summary>
         [SerializeField]
         [Tooltip("Minimum time between player follow target swaps")]
-        private UnityEngine.InputSystem.InputActionReference forwardAction;
+        private InputActionReference forwardAction;
 
         /// <summary>
         /// Action to move to previous spectator object.
         /// </summary>
         [SerializeField]
         [Tooltip("Minimum time between player follow target swaps")]
-        private UnityEngine.InputSystem.InputActionReference backwardAction;
+        private InputActionReference backwardAction;
 
         /// <summary>
         /// What is the player currently following?

--- a/Assets/Scripts/Spectator/SpectatorFollow.cs.meta
+++ b/Assets/Scripts/Spectator/SpectatorFollow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99936fe44edda614da7345ec5e1fe84e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/TestInputSystem.inputactions
+++ b/Assets/Tests/TestInputSystem.inputactions
@@ -30,14 +30,6 @@
                     "interactions": ""
                 },
                 {
-                    "name": "Sprint",
-                    "type": "Button",
-                    "id": "3aa4111b-bb68-412d-bd3f-17bda7f2ca5d",
-                    "expectedControlType": "Button",
-                    "processors": "",
-                    "interactions": ""
-                },
-                {
                     "name": "Fire",
                     "type": "Button",
                     "id": "e1d5dee9-5e26-4579-9d27-657776fa136c",
@@ -184,17 +176,6 @@
                     "processors": "",
                     "groups": "",
                     "action": "Interact",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "6663e169-adaf-4d37-af8d-c5ce731ea772",
-                    "path": "<Keyboard>/leftShift",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
-                    "action": "Sprint",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },


### PR DESCRIPTION
# Description

Added a basic spectator camera and player into game flow
* When player joins mid game, they are made a spectator
* Spectators either follow spectator points on the map or follow a player on the map
* Spectators can swap between targets by pressing left shift or left ctrl
* Spectators can rotate the camera using the mouse around their target
* Players can turn into spectators when they enter a specific zone (aka finish line)

There is no auto end round when all players finish the level but it's what we have so far :)

# How Has This Been Tested?

Tested locally on one and multiple clients to ensure spectator player works in the following cases
* Switching between targets
* Joining mid game
* Hitting finish line (might have cheated a bit for this one)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
