### PR TITLE
Debugged existing spectator code not get stuck in colliders

### DIFF
--- a/Assets/Prefabs/Player/PlayerVariation.prefab
+++ b/Assets/Prefabs/Player/PlayerVariation.prefab
@@ -661,6 +661,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: da859f811529b0b428b2f67bec07515c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  ignoreCollider: {fileID: 774360562829986131}
 --- !u!1 &3969404203279134107
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player/SpectatorPlayer.prefab
+++ b/Assets/Prefabs/Player/SpectatorPlayer.prefab
@@ -106,10 +106,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0.1
-  minSwapTime: 0.05
   forwardAction: {fileID: -8014285966804362514, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
   backwardAction: {fileID: -2296981732642237548, guid: 4852f26cd5a256d49a424ab8104ce90f, type: 3}
-  target: {fileID: 0}
 --- !u!114 &7336392193004563287
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Spectator/Followable.cs
+++ b/Assets/Scripts/Spectator/Followable.cs
@@ -21,6 +21,11 @@ namespace PropHunt.Spectator
         /// </summary>
         public Guid Id => id;
 
+        /// <summary>
+        /// GameObject to ignore collider of when following this object
+        /// </summary>
+        public GameObject ignoreCollider;
+
         public int CompareTo(Followable other)
         {
             return id.CompareTo(other.id);

--- a/Assets/Scripts/Utils/PhysicsUtils.cs
+++ b/Assets/Scripts/Utils/PhysicsUtils.cs
@@ -1,4 +1,5 @@
 
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace PropHunt.Utils
@@ -19,6 +20,29 @@ namespace PropHunt.Utils
             foreach (RaycastHit hit in hits)
             {
                 if (hit.collider.gameObject == target && hit.distance < closest.distance)
+                {
+                    hitSomething = true;
+                    closest = hit;
+                }
+            }
+            return hitSomething;
+        }
+
+        /// <summary>
+        /// Filters a set of raycast hits for the first hit that is not 
+        /// of a collider attached to a given game object
+        /// </summary>
+        /// <param name="ignoreList">Game objects to ignore when checking for collider hit</param>
+        /// <param name="hits">All of the hits to process</param>
+        /// <param name="closest">Closest hit that is attached to the ignored object</param>
+        /// <returns>True if a hit was detected, false otherwise</returns>
+        public static bool FilterForFirstHitIgnore(List<GameObject> ignoreList, RaycastHit[] hits, out RaycastHit closest)
+        {
+            bool hitSomething = false;
+            closest = new RaycastHit { distance = Mathf.Infinity };
+            foreach (RaycastHit hit in hits)
+            {
+                if (!ignoreList.Contains(hit.collider.gameObject) && hit.distance < closest.distance)
                 {
                     hitSomething = true;
                     closest = hit;
@@ -89,6 +113,24 @@ namespace PropHunt.Utils
         /// Compute the first object hit while ignoring a given object for a raycast.
         /// Will include overlapping objects if objects overlap.
         /// </summary>
+        /// <param name="ignoreList">Object to ignore from raycast</param>
+        /// <param name="source">Source position of raycast</param>
+        /// <param name="direction">Direction of raycast</param>
+        /// <param name="distance">Distance of raycast</param>
+        /// <param name="layerMask">Laymask for raycast</param>
+        /// <param name="queryTriggerInteraction">Query trigger interaction for raycast</param>
+        /// <param name="closest">The closest raycast hit event</param>
+        /// <returns>True if a hit was detected, false otherwise.</returns>
+        public static bool RaycastFirstHitIgnore(List<GameObject> ignoreList, Vector3 source, Vector3 direction, float distance,
+            LayerMask layerMask, QueryTriggerInteraction queryTriggerInteraction, out RaycastHit closest)
+        {
+            return FilterForFirstHitIgnore(ignoreList, Physics.RaycastAll(source, direction, distance, layerMask, queryTriggerInteraction), out closest);
+        }
+
+        /// <summary>
+        /// Compute the first object hit while ignoring a given object for a raycast.
+        /// Will include overlapping objects if objects overlap.
+        /// </summary>
         /// <param name="ignore">Object to ignore from raycast</param>
         /// <param name="source">Source position of raycast</param>
         /// <param name="direction">Direction of raycast</param>
@@ -101,6 +143,25 @@ namespace PropHunt.Utils
             LayerMask layerMask, QueryTriggerInteraction queryTriggerInteraction, out RaycastHit closest)
         {
             return FilterForFirstHitIgnore(ignore, Physics.RaycastAll(source, direction, distance, layerMask, queryTriggerInteraction), out closest);
+        }
+
+        /// <summary>
+        /// Compute the first object hit while ignoring a given object for a spherecast.
+        /// Will include overlapping objects if objects overlap.
+        /// </summary>
+        /// <param name="ignoreList">Objects to ignore from spherecast</param>
+        /// <param name="source">Source position of spherecast</param>
+        /// <param name="radius">Radius spherecast</param>
+        /// <param name="direction">Direction of spherecast</param>
+        /// <param name="distance">Distance of spherecast</param>
+        /// <param name="layerMask">Laymask for spherecast</param>
+        /// <param name="queryTriggerInteraction">Query trigger interaction for spherecast</param>
+        /// <param name="closest">The closest raycast hit event</param>
+        /// <returns>True if a hit was detected, false otherwise.</returns>
+        public static bool SphereCastFirstHitIgnore(List<GameObject> ignoreList, Vector3 source, float radius, Vector3 direction, float distance,
+            LayerMask layerMask, QueryTriggerInteraction queryTriggerInteraction, out RaycastHit closest)
+        {
+            return FilterForFirstHitIgnore(ignoreList, Physics.SphereCastAll(source, radius, direction, distance, layerMask, queryTriggerInteraction), out closest);
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Debugged existing code to be able to selectively ignore objects when attempting to figure out what the player camera is colliding with. 

# How Has This Been Tested?

This has been tested locally on multiple clients. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
