### PR TITLE
Jittery Fans

### DIFF
--- a/Assets/Scripts/Character/CameraController.cs
+++ b/Assets/Scripts/Character/CameraController.cs
@@ -175,7 +175,7 @@ namespace PropHunt.Character
             pitchChange = look.y;
         }
 
-        public void Update()
+        public void LateUpdate()
         {
             if (!networkService.isLocalPlayer)
             {

--- a/Assets/Scripts/Character/CameraController.cs.meta
+++ b/Assets/Scripts/Character/CameraController.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 8
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Character/KinematicCharacterController.cs
+++ b/Assets/Scripts/Character/KinematicCharacterController.cs
@@ -373,7 +373,7 @@ namespace PropHunt.Character
             feetFollowObj.transform.SetParent(transform);
         }
 
-        public void FixedUpdate()
+        public void Update()
         {
             if (!networkService.isLocalPlayer)
             {
@@ -381,7 +381,7 @@ namespace PropHunt.Character
                 return;
             }
 
-            float deltaTime = unityService.fixedDeltaTime;
+            float deltaTime = unityService.deltaTime;
 
             // If player is not allowed to move, stop player movement
             if (PlayerInputManager.playerMovementState == PlayerInputState.Deny)

--- a/Assets/Scripts/Environment/FixedRigidbodySet.cs
+++ b/Assets/Scripts/Environment/FixedRigidbodySet.cs
@@ -56,9 +56,9 @@ namespace PropHunt.Environment
             }
         }
 
-        public void FixedUpdate()
+        public void Update()
         {
-            float deltaTime = unityService.fixedDeltaTime;
+            float deltaTime = unityService.deltaTime;
 
             // move object by velocity
             transform.position += deltaTime * linearVelocity;

--- a/Assets/Scripts/Environment/FixedRigidbodySet.cs
+++ b/Assets/Scripts/Environment/FixedRigidbodySet.cs
@@ -44,7 +44,7 @@ namespace PropHunt.Environment
         [Tooltip("Linear velocity of object in units per second for each axis")]
         protected Vector3 linearVelocity;
 
-        public void Start()
+        public override void OnStartServer()
         {
             if (localRotation)
             {
@@ -58,11 +58,6 @@ namespace PropHunt.Environment
 
         public void FixedUpdate()
         {
-            if (!isServer)
-            {
-                return;
-            }
-
             float deltaTime = unityService.fixedDeltaTime;
 
             // move object by velocity

--- a/Assets/Tests/EditMode/Character/CameraControllerTests.cs
+++ b/Assets/Tests/EditMode/Character/CameraControllerTests.cs
@@ -51,14 +51,14 @@ namespace Tests.EditMode.Character
         public void TestCameraFollowNotLocal()
         {
             this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(false);
-            this.cameraController.Update();
+            this.cameraController.LateUpdate();
         }
 
         [Test]
         public void TestCameraFollowLocal()
         {
             this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
-            this.cameraController.Update();
+            this.cameraController.LateUpdate();
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace Tests.EditMode.Character
             this.cameraController.maxCameraDistance = 2.0f;
             this.cameraController.currentDistance = 2.0f;
             this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
-            this.cameraController.Update();
+            this.cameraController.LateUpdate();
         }
 
         [Test]
@@ -86,9 +86,9 @@ namespace Tests.EditMode.Character
             this.cameraController.shadowOnlyDistance = 0.0f;
             this.cameraController.ditherDistance = 5.0f;
             this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
-            this.cameraController.Update();
+            this.cameraController.LateUpdate();
             this.cameraController.ditherDistance = 0.0f;
-            this.cameraController.Update();
+            this.cameraController.LateUpdate();
         }
 
         [Test]

--- a/Assets/Tests/EditMode/Character/KinematicCharacterControllerTests.cs
+++ b/Assets/Tests/EditMode/Character/KinematicCharacterControllerTests.cs
@@ -56,7 +56,7 @@ namespace Tests.EditMode.Character
             this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
             this.kcc.gameObject.AddComponent<Rigidbody>();
             this.kcc.inputMovement = new Vector3(0, 0, 1.0f);
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
             Assert.IsTrue(this.kcc.transform.position == Vector3.zero);
         }
 
@@ -65,7 +65,7 @@ namespace Tests.EditMode.Character
         {
             this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(false);
             // this.kcc.Update();
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
         }
 
         [Test]
@@ -75,13 +75,13 @@ namespace Tests.EditMode.Character
             PlayerInputManager.playerMovementState = PlayerInputState.Deny;
             this.networkServiceMock.Setup(e => e.isLocalPlayer).Returns(true);
             // this.kcc.Update();
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
 
             Assert.IsTrue(this.kcc.transform.position == Vector3.zero);
 
             PlayerInputManager.playerMovementState = PlayerInputState.Allow;
             // this.kcc.Update();
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
 
             Assert.IsTrue(this.kcc.transform.position == Vector3.zero);
         }
@@ -117,14 +117,14 @@ namespace Tests.EditMode.Character
                     normal = Vector3.up
                 }
             );
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
             Assert.IsTrue(this.kcc.StandingOnGround);
             Assert.IsFalse(this.kcc.Falling);
 
             // Allow player to attempt to jump
             this.kcc.OnJump(new UnityEngine.InputSystem.InputAction.CallbackContext());
             this.kcc.attemptingJump = true;
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
 
             // Assert that we are jumping
             UnityEngine.Debug.Log(this.kcc.Velocity);
@@ -147,7 +147,7 @@ namespace Tests.EditMode.Character
                     normal = Vector3.up
                 }
             );
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
             Assert.IsTrue(this.kcc.StandingOnGround);
             Assert.IsTrue(!this.kcc.Falling);
 
@@ -162,7 +162,7 @@ namespace Tests.EditMode.Character
                     normal = Vector3.right
                 }
             );
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
             Assert.IsTrue(this.kcc.StandingOnGround);
             Assert.IsTrue(this.kcc.Falling);
 
@@ -175,7 +175,7 @@ namespace Tests.EditMode.Character
                     hit = false
                 }
             );
-            this.kcc.FixedUpdate();
+            this.kcc.Update();
             Assert.IsTrue(!this.kcc.StandingOnGround);
             Assert.IsTrue(this.kcc.Falling);
         }


### PR DESCRIPTION
# Description

Fixed the fan behaviour that cause them to 'jitter' when a player that was a client was following them or standing on them. Had to switch from using the fixed update function to using the Update Function. probably a sub setting within Mirror configures this but it seems like things that need to be synchronized over the network are best done in the Update function instead of FixedUpdate.

# How Has This Been Tested?

Tested locally with multiple clients as well as in the editor. Ensured that the fans do not constantly jitter. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
