### PR TITLE
fixed some jittery behavior in player movement on oddly shaped floors

### DIFF
--- a/Assets/Scripts/Character/KinematicCharacterController.cs
+++ b/Assets/Scripts/Character/KinematicCharacterController.cs
@@ -600,7 +600,7 @@ namespace PropHunt.Character
             }
             // Check if we were standing on moving ground the previous frame
             IMovingGround movingGround = floor == null ? null : floor.GetComponent<IMovingGround>();
-            if (movingGround == null || FallingAngle(maxJumpAngle))
+            if (movingGround == null || !onGround || distanceToGround > groundedDistance)
             {
                 // We aren't standing on something, don't do anything
                 feetFollowObj.transform.parent = transform;
@@ -680,7 +680,7 @@ namespace PropHunt.Character
             this.onGround = didHit;
             this.surfaceNormal = hit.normal;
             this.groundHitPosition = hit.distance > 0 ? hit.point : transform.position;
-            this.floor = hit.collider != null && StandingOnGround ? hit.collider.gameObject : null;
+            this.floor = hit.collider != null ? hit.collider.gameObject : null;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Adjusted how player floor is computed to hopefully handle oddly shaped floors better

# How Has This Been Tested?

Tested locally in editor with lots of shapes. Appears that moving floors with very odd shapes (complex convex surfaces) that are moving quickly cause the player to get partially stuck in the floor. The moving floor code still works but the player is stuck in the ground a bit. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
