### PR TITLE
Adjusting default mouse sensitivity

### DIFF
--- a/Assets/Scripts/Character/PlayerInputState.cs
+++ b/Assets/Scripts/Character/PlayerInputState.cs
@@ -29,8 +29,8 @@ namespace PropHunt.Character
         public static readonly float maximumMouseSensitivity = 1.0f;
 
         /// <summary>
-        /// Mouse sensitivity multiplier (should be between 0.1 and 5.0 hopefully)
+        /// Mouse sensitivity multiplier (should be between 0.05 and 1.0 hopefully)
         /// </summary>
-        public static float mouseSensitivity = 0.75f;
+        public static float mouseSensitivity = 0.25f;
     }
 }

--- a/Assets/Scripts/UI/Actions/ChangeMouseSensitivity.cs
+++ b/Assets/Scripts/UI/Actions/ChangeMouseSensitivity.cs
@@ -57,7 +57,8 @@ namespace PropHunt.UI.Actions
         /// </summary>
         public void Awake()
         {
-            PlayerInputManager.mouseSensitivity = PlayerPrefs.GetFloat(mouseSensitivityPlayerPref, 1.0f);
+            PlayerInputManager.mouseSensitivity = PlayerPrefs.GetFloat(
+                mouseSensitivityPlayerPref, PlayerInputManager.mouseSensitivity);
             slider.SetValueWithoutNotify(GetSliderValue(PlayerInputManager.mouseSensitivity));
             // Update saved and current value on player input
             slider.onValueChanged.AddListener(value =>


### PR DESCRIPTION
# Description

Adjusted default mouse sensitivity to not be maxed out.

# How Has This Been Tested?

Tested locally with resetting unity settings. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
