### PR TITLE
Adjusted player movement settings

### DIFF
--- a/Assets/Prefabs/Player/PlayerVariation.prefab
+++ b/Assets/Prefabs/Player/PlayerVariation.prefab
@@ -239,9 +239,9 @@ MonoBehaviour:
   stepUpDepth: 0.05
   verticalSnapUp: 0.35
   snapBufferTime: 0.05
-  earlyStopProneThreshold: 0.2
-  thresholdAngularVelocity: 15
-  thresholdVelocity: 1
+  earlyStopProneThreshold: 0.05
+  thresholdAngularVelocity: 240
+  thresholdVelocity: 3
 --- !u!114 &6378087374586662482
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Description

Adjusted player prone settings to adjust how fast a player can recover once they are hit by an object. 

# How Has This Been Tested?

Tested locally as well as with multiple clients to ensure it works as expected. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
