### PR TITLE
Relative Velocity Knock Prone

### DIFF
--- a/Assets/Prefabs/Environment/Small Items/Small Gear.prefab
+++ b/Assets/Prefabs/Environment/Small Items/Small Gear.prefab
@@ -70,6 +70,21 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3b65b70a1a4a9404abccddc6c944a40e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2707821320520481700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1415272902686009912}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31141d0fec2ca374592f31a8fdbad06f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  proneTime: 1.5
+  thresholdRelativeVelocity: 1
+  percentThresholdVelocity: 0.5
 --- !u!114 &9110951515132931801
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Player/PlayerVariation.prefab
+++ b/Assets/Prefabs/Player/PlayerVariation.prefab
@@ -239,8 +239,8 @@ MonoBehaviour:
   stepUpDepth: 0.05
   verticalSnapUp: 0.35
   snapBufferTime: 0.05
-  earlyStopProneThreshold: 0.05
-  thresholdAngularVelocity: 240
+  earlyStopProneThreshold: 0.1
+  thresholdAngularVelocity: 120
   thresholdVelocity: 3
 --- !u!114 &6378087374586662482
 MonoBehaviour:

--- a/Assets/Scenes/Factory.unity
+++ b/Assets/Scenes/Factory.unity
@@ -4390,7 +4390,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4802a01e94b1afd498a51a6bf302c089, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  order: 2
+  order: 3
   offset: {x: 1, y: 1}
   rows: 3
   cols: 9

--- a/Assets/Scripts/Character/KinematicCharacterController.cs
+++ b/Assets/Scripts/Character/KinematicCharacterController.cs
@@ -486,8 +486,7 @@ namespace PropHunt.Character
                 // Exclude the floor's velocity from the linear speed calculation for checking prone
                 float movingSpeedCalculation = Mathf.Max(
                     0,
-                    linearSpeed - (movingGroundDisplacement/fixedDeltaTime).magnitude);
-                UnityEngine.Debug.Log($"speed:{linearSpeed} moving:{movingSpeedCalculation} groundDisp:{movingGroundDisplacement.ToString("F3")} linThreshold:{movingSpeedCalculation <= thresholdVelocity} angThreshold:{angularSpeed <= thresholdAngularVelocity}");
+                    linearSpeed - (movingGroundDisplacement / fixedDeltaTime).magnitude);
 
                 // If player's velocity is less than threshold for threshold time, exit prone early
                 if (movingSpeedCalculation <= thresholdVelocity &&

--- a/Assets/Scripts/Character/KinematicCharacterController.cs
+++ b/Assets/Scripts/Character/KinematicCharacterController.cs
@@ -397,6 +397,16 @@ namespace PropHunt.Character
         private Quaternion previousRotation;
 
         /// <summary>
+        /// Player's displacement caused by the moving floor this update.
+        /// </summary>
+        private Vector3 movingGroundDisplacement;
+
+        /// <summary>
+        /// linear velocity of the player measured via displacement from the previous movement.
+        /// </summary>
+        public Vector3 LinearVelocity { get; private set; }
+
+        /// <summary>
         /// Can the player jump right now.
         /// </summary>
         public bool CanJump => elapsedFalling >= 0 && (!FallingAngle(maxJumpAngle) || elapsedFalling <= coyoteTime) &&
@@ -451,11 +461,11 @@ namespace PropHunt.Character
 
             float fixedDeltaTime = Time.fixedDeltaTime;
 
-            float deltaPos = (transform.position - this.previousPosition).magnitude;
-            float deltaAngle = Mathf.Rad2Deg * Quaternion.Angle(transform.rotation, this.previousRotation);
+            LinearVelocity = (transform.position - this.previousPosition) / fixedDeltaTime;
+            float deltaAngle = Quaternion.Angle(transform.rotation, this.previousRotation);
 
-            float linVel = deltaPos / fixedDeltaTime;
-            float angVel = deltaAngle / fixedDeltaTime;
+            float linearSpeed = LinearVelocity.magnitude;
+            float angularSpeed = deltaAngle / fixedDeltaTime;
 
             this.previousPosition = transform.position;
             this.previousRotation = transform.rotation;
@@ -473,9 +483,15 @@ namespace PropHunt.Character
                 this.feetFollowObj.transform.localRotation = Quaternion.identity;
                 this.distanceToGround = Mathf.Infinity;
 
+                // Exclude the floor's velocity from the linear speed calculation for checking prone
+                float movingSpeedCalculation = Mathf.Max(
+                    0,
+                    linearSpeed - (movingGroundDisplacement/fixedDeltaTime).magnitude);
+                UnityEngine.Debug.Log($"speed:{linearSpeed} moving:{movingSpeedCalculation} groundDisp:{movingGroundDisplacement.ToString("F3")} linThreshold:{movingSpeedCalculation <= thresholdVelocity} angThreshold:{angularSpeed <= thresholdAngularVelocity}");
+
                 // If player's velocity is less than threshold for threshold time, exit prone early
-                if (linVel <= thresholdVelocity &&
-                    angVel <= thresholdAngularVelocity)
+                if (movingSpeedCalculation <= thresholdVelocity &&
+                    angularSpeed <= thresholdAngularVelocity)
                 {
                     elapsedUnderThreshold += fixedDeltaTime;
                     if (elapsedUnderThreshold >= earlyStopProneThreshold)
@@ -683,6 +699,10 @@ namespace PropHunt.Character
         /// </summary>
         public void MoveWithGround()
         {
+            movingGroundDisplacement = Vector3.zero;
+
+            Vector3 moveWithGroundStart = transform.position;
+
             if (feetFollowObj.transform.parent != transform)
             {
                 transform.position = feetFollowObj.transform.position + footOffset;
@@ -711,6 +731,8 @@ namespace PropHunt.Character
 
             transform.position += (verticalSnapDown * 0.5f) * surfaceNormal;
             SnapPlayerDown(-surfaceNormal, verticalSnapDown);
+
+            movingGroundDisplacement = transform.position - moveWithGroundStart;
         }
 
         /// <summary>

--- a/Assets/Scripts/Environment/HitPlayerProneVelocity.cs
+++ b/Assets/Scripts/Environment/HitPlayerProneVelocity.cs
@@ -1,0 +1,93 @@
+using PropHunt.Character;
+using UnityEngine;
+
+namespace PropHunt.Environment
+{
+    /// <summary>
+    /// Hit players prone when they are hit by this object and have a high enough
+    /// relative velocity to the player.
+    /// </summary>
+    public class HitPlayerProneVelocity : MonoBehaviour
+    {
+        /// <summary>
+        /// How long should a player be knocked prone (minimum time) after they are hit?
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Time to set player prone when hit by this.")]
+        private float proneTime = 3.0f;
+
+        /// <summary>
+        /// Threshold relative velocity between the player and object to hit that
+        /// give player prone.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Threshold relative velocity required to knock the player prone.")]
+        private float thresholdRelativeVelocity = 1.0f;
+
+        /// <summary>
+        /// Percent of threshold velocity this item must travel at to knock the player prone.
+        /// </summary>
+        [SerializeField]
+        [Range(0, 1)]
+        [Tooltip("Percent of threshold velocity this object must travel at to knock the player prone.")]
+        private float percentThresholdVelocity = 0.5f;
+
+        /// <summary>
+        /// Rigidbody associated with this object.
+        /// </summary>
+        private Rigidbody body;
+
+        /// <summary>
+        /// Network Rigidbody associated with this object
+        /// </summary>
+        private NetworkRigidbody networkRigidbody;
+
+        public Vector3 GetVelocity()
+        {
+            if (networkRigidbody != null)
+            {
+                return networkRigidbody.netVelocity.Value;
+            }
+            if (body != null)
+            {
+                return body.velocity;
+            }
+            return Vector3.zero;
+        }
+
+        public void Awake()
+        {
+            this.body = GetComponent<Rigidbody>();
+            this.networkRigidbody = GetComponent<NetworkRigidbody>();
+        }
+
+        public void OnCollisionEnter(Collision collision)
+        {
+            PushPlayer(collision);
+        }
+
+        public void PushPlayer(Collision collision, float forceMod = 1.2f)
+        {
+
+            if (collision.gameObject == null)
+            {
+                return;
+            }
+            KinematicCharacterController kcc = collision.gameObject.GetComponent<KinematicCharacterController>();
+            if (kcc == null || !kcc.IsLocalPlayer)
+            {
+                return;
+            }
+            Vector3 velocity = GetVelocity();
+            if ((kcc.LinearVelocity - velocity).magnitude > thresholdRelativeVelocity &&
+                (percentThresholdVelocity == 0 || 
+                    velocity.magnitude > thresholdRelativeVelocity * percentThresholdVelocity))
+            {
+                // Knock the player prone for prone time seconds
+                kcc.KnockPlayerProne(proneTime);
+                Vector3 point = collision.contacts[0].point;
+                collision.rigidbody.AddForceAtPosition(GetComponent<Rigidbody>().GetPointVelocity(point) * forceMod, point);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Environment/HitPlayerProneVelocity.cs
+++ b/Assets/Scripts/Environment/HitPlayerProneVelocity.cs
@@ -80,7 +80,7 @@ namespace PropHunt.Environment
             }
             Vector3 velocity = GetVelocity();
             if ((kcc.LinearVelocity - velocity).magnitude > thresholdRelativeVelocity &&
-                (percentThresholdVelocity == 0 || 
+                (percentThresholdVelocity == 0 ||
                     velocity.magnitude > thresholdRelativeVelocity * percentThresholdVelocity))
             {
                 // Knock the player prone for prone time seconds

--- a/Assets/Scripts/Environment/HitPlayerProneVelocity.cs.meta
+++ b/Assets/Scripts/Environment/HitPlayerProneVelocity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31141d0fec2ca374592f31a8fdbad06f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description

Added new feature to knock players prone based on relative velocity of collision.

Based on relative velocity of a collision, players can now be knocked prone when hit by an object moving quickly. 

![hit with a gear](https://user-images.githubusercontent.com/3240136/133917320-abc24d6c-ec88-48a3-ae69-4c0fb636df75.gif)

# How Has This Been Tested?

This has been tested locally as well as with multiple clients to ensure it performs as expected. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
